### PR TITLE
Prevent display of pages marked not visible in bottom navigation

### DIFF
--- a/templates/sections.html.twig
+++ b/templates/sections.html.twig
@@ -13,8 +13,8 @@
             {{ page.content }}
 
             <p class="prev-next">
-                {% set siblings = page.parent.children() %}
-                {% set children = page.children() %}
+                {% set siblings = page.parent.children.visible() %}
+                {% set children = page.children.visible() %}
 
                 {% if not(page.parent.slug == 'pages') %}
 


### PR DESCRIPTION
Prevent display in bottom navigation of pages that are marked not visible
Pages marked not visible are (justly) suppressed in the menu on the left side
However, they are displayed in the navigation at the bottom of the page instead of also being suppressed.