### PR TITLE
Fix order in which images in inheriting themes should be searched

### DIFF
--- a/quark-open-publishing.php
+++ b/quark-open-publishing.php
@@ -39,7 +39,7 @@ class QuarkOpenPublishing extends Quark
     public function onTwigLoader()
     {
         $theme_paths = Grav::instance()['locator']->findResources('theme://images');
-        foreach (array_reverse($theme_paths) as $images_path) {
+        foreach ($theme_paths as $images_path) {
             $this->grav['twig']->addPath($images_path, 'images');
         }
     }


### PR DESCRIPTION
Remove `array_reverse` when looping the path of themes.